### PR TITLE
Fix invalid perfdata output

### DIFF
--- a/check_jitsi.py
+++ b/check_jitsi.py
@@ -165,7 +165,8 @@ class CheckJitsi:
         if metrics:
             perfdata = '|'
             perfdata += ' '.join(
-                ["{}={}".format(k, int(v)) if type(v) == bool else "{}={}".format(k, v) for k, v in metrics.items()])
+                ["{}={}".format(k, int(v)) if type(v) == bool 
+                 else "{}={}".format(k, v) if type(v) != list and k != 'version' else '' for k, v in metrics.items()])
 
         print(message, perfdata)
         sys.exit(rc.value)
@@ -206,7 +207,7 @@ class CheckJitsi:
             self._state = CheckState.WARNING
 
         self.check_result(self._state, msg,
-                          {name: "{};;{};{}".format(value, self.args.threshold_warning, self.args.threshold_critical)})
+                          {name: "{};{};{}".format(value, self.args.threshold_warning, self.args.threshold_critical)})
 
     def check(self):
         if self.args.mode == 'health':


### PR DESCRIPTION
By omitting conferences_by_audio_senders, conferences_by_video_senders and version strings, the perfdata output for -m health --all-metrics should be in line with icinga's format. 

Removing one of the semicolons in the output of _check_simple should apply warning and critical to the corresponding icinga2 performance labels instead of warning being critical and critical becoming min.